### PR TITLE
Fixed issue with getNumberOfVisibleElements()

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -474,7 +474,7 @@ var Element = {
       var deferred = Q.defer();
       var res = JSON.parse(result);
       var resLength = res.value.length;
-      var curLength = 1;
+      var curLength = 0;
       var visibleElement = [];
 
       res.value.forEach(function (element) {


### PR DESCRIPTION
curLength was set to 1 but there was a call to curLength++ before looping through the elements so it would always skip for the first element and therefore always be 1 off from the true number.  I set curLength to 0 so it will not skip the first element.
