### PR TITLE
Added sendKeys() method that can be used on any element, not just inputs

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -381,6 +381,39 @@ var Element = {
   },
 
   /**
+   * Sends keys to an element (whether or not it is an input)
+   *
+   * @method sendKeys
+   * @param {string} selector Selector expression to find the element
+   * @param {string} hash Unique hash of that fn call
+   * @chainable
+   */
+
+  sendKeys: function (selector, keystrokes, hash) {
+    this.actionQueue.push(this.webdriverClient.element.bind(this.webdriverClient, selector));
+    this.actionQueue.push(this.webdriverClient.sendKeys.bind(this.webdriverClient, keystrokes));
+    this.actionQueue.push(this._sendKeysCb.bind(this, selector, keystrokes, hash));
+    return this;
+  },
+
+  /**
+   * Sends out an event with the results of the `sendKeys` call
+   *
+   * @method _sendKeysCb
+   * @param {string} selector Selector expression to find the element
+   * @param {string} hash Unique hash of that fn call
+   * @return {object} promise Type promise
+   * @private
+   */
+
+  _sendKeysCb: function (selector, keystrokes, hash) {
+    var deferred = Q.defer();
+    this.events.emit('driver:message', {key: 'sendKeys', value: selector, keystrokes: keystrokes, uuid: hash, hash: hash});
+    deferred.resolve();
+    return deferred.promise;
+  },
+
+  /**
    * Wait for an element for a specific amount of time
    *
    * @method waitForElement


### PR DESCRIPTION
Part of the code to allow for sending keyboard commands to any input and not just inputs which is what type() does.
