### PR TITLE
load canary if normal on doesn't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,15 @@ var fs = require('fs');
 var Q = require('q');
 
 // int. libs
-var WD = require('dalek-internal-webdriver');
+try {
+  var WD = require('dalek-internal-webdriver');
+} catch (e) {
+  try {
+    var WD = require('dalek-internal-webdriver-canary');
+  } catch (e) {
+    return e;
+  }
+}
 
 /**
  * Loads the webdriver client,


### PR DESCRIPTION
This file needs to check for the canary mdoule if the regular one does not load (like other modules do).
