### PR TITLE
Improve logging ('WAITFORELEMENT #my-selector' instead of just 'WAITFORELEMNT')

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -635,7 +635,7 @@ var Element = {
 
   _waitForElementCb: function (selector, hash, uuid) {
     var deferred = Q.defer();
-    this.events.emit('driver:message', {key: 'waitForElement', selector: selector, uuid: uuid, hash: hash});
+    this.events.emit('driver:message', {key: 'waitForElement', selector: selector, value: selector, uuid: uuid, hash: hash});
     deferred.resolve();
     return deferred.promise;
   },


### PR DESCRIPTION
in `_waitForElementCb()` send the selector in the `.value` field, because it is the one
passed later to 'report:action' and used to print the log message.
same is the case already for other actions (e.g. `_clickCb`, `_submitCb`, etc.)

another possible solution to achieve the same result was modifying
actions.js, line 1356 (in the dalek base repository) to pass:
    `value: data.value ? data.value : data.selector`
to 'report:action',
but it seemed more intrusive to me ..

Thank you!
