### PR TITLE
Fix screenshot folder creation bug on windows

### DIFF
--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -93,8 +93,9 @@ var Screenshot = {
    */
 
   _recursiveMakeDirSync: function (path) {
+    var normalizedPath = require('path').normalize(path);
     var pathSep = require('path').sep;
-    var dirs = path.split(pathSep);
+    var dirs = normalizedPath.split(pathSep);
     var root = '';
 
     while (dirs.length > 0) {


### PR DESCRIPTION
If the screenshot path is given with unix style path separators, as it probably should, (e.g. 'test/screenshot/:browser_:viewport_:timestamp.png') the determined path separator from require('path').sep will still be \ on windows systems.

This means that in the following split(pathSep) and most of the following code will not work, because the path contains only / but the separator is \.

Normalizing the path before any further operations fixes this.